### PR TITLE
0610 utc 이슈 수정

### DIFF
--- a/src/main/java/com/sh/app/member/service/MemberService.java
+++ b/src/main/java/com/sh/app/member/service/MemberService.java
@@ -47,6 +47,8 @@ import org.springframework.security.web.authentication.logout.SecurityContextLog
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -212,10 +214,13 @@ public class MemberService {
     }
 
     public MemberReservationDto findPastReservationsById(Long id) {
+        System.out.println("내가 본 영화를 조회하는 구간입니다....");
+        ZoneId zoneId = ZoneId.of("Asia/Seoul");
+        LocalDateTime localDateTime = LocalDateTime.now(zoneId);
         Member member = memberRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Member not found with id: " + id));
 
-        List<Reservation> pastReservations = reservationRepository.findPastReservationsById(id);
+        List<Reservation> pastReservations = reservationRepository.findPastReservationsById(id,localDateTime);
         
         Set<ReservationInfoDto> reservationInfoDtos = pastReservations.stream()
                 .map(this::convertToReservationInfoDto)

--- a/src/main/java/com/sh/app/memberLikeCinema/repository/MemberLikeCinemaRepository.java
+++ b/src/main/java/com/sh/app/memberLikeCinema/repository/MemberLikeCinemaRepository.java
@@ -14,7 +14,7 @@ public interface MemberLikeCinemaRepository extends JpaRepository<MemberLikeCine
     @Query("SELECT mlc FROM MemberLikeCinema mlc JOIN FETCH mlc.cinema WHERE mlc.member.id = :memberId")
     List<MemberLikeCinema> findByMemberIdWithCinema(@Param("memberId") Long memberId);
 
-    @Query("SELECT mlc, c.region_cinema FROM MemberLikeCinema mlc JOIN FETCH mlc.cinema c WHERE mlc.member.id = :memberId")
+    @Query("SELECT mlc, c.region_cinema FROM MemberLikeCinema mlc JOIN FETCH mlc.cinema c WHERE mlc.member.id = :memberId order by c.region_cinema")
     List<MemberLikeCinema> findByMemberIdWithCinema2(@Param("memberId") Long memberId);
 
     int countByMemberId(Long memberId);

--- a/src/main/java/com/sh/app/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/sh/app/reservation/repository/ReservationRepository.java
@@ -4,6 +4,7 @@ import com.sh.app.reservation.entity.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -17,9 +18,10 @@ public interface ReservationRepository extends JpaRepository<Reservation, String
 //    @Query("select r from Reservation r join fetch r.schedule s where r.memberId = :id and s.time < current_timestamp")
 // @Query("SELECT r FROM Reservation r JOIN FETCH r.schedule s JOIN FETCH s.movie JOIN FETCH r.seats JOIN FETCH s.theater t JOIN FETCH
 // t.cinema JOIN FETCH r.review WHERE r.memberId = :id AND s.time < CURRENT_TIMESTAMP")  // schema 에서 reservation 테이블에 review_id 컬럼 추가한 후 사용
+    //0610 시간대를 위한 localDateTime 매개변수 추가
     @Query("select r from Reservation r join fetch r.schedule s join fetch s.movie join fetch r.seats join fetch s.theater t join fetch " +
-            "t.cinema where r.memberId = :id and s.time < current_timestamp")
-    List<Reservation> findPastReservationsById(Long id);
+            "t.cinema where r.memberId = :id and s.time < :localDateTime")
+    List<Reservation> findPastReservationsById(Long id, LocalDateTime localDateTime);
 
     @Query("SELECT COUNT(r) FROM Reservation r WHERE r.schedule.movie.id = :id")
     long countByMovieId(Long id);

--- a/src/main/java/com/sh/app/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/sh/app/schedule/repository/ScheduleRepository.java
@@ -8,13 +8,21 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.sql.Timestamp;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+
+    LocalDateTime localDateTime = LocalDateTime.now();
+    ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneId.of("Asia/Seoul"));
+    Timestamp timestamp = Timestamp.valueOf(zonedDateTime.toLocalDateTime());
 
     @Query("from Schedule s join fetch s.theater t where t.id = :theaterId")
     List<Schedule> findByTheaterId(Long theaterId);
@@ -53,9 +61,11 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
         JOIN schedule s ON s.theater_id = t.id
         JOIN movie_list ml ON ml.cinema_id = c.id
         JOIN movie m ON m.id = ml.movie_id AND m.id = s.movie_id
-        WHERE (c.id = :id AND s.sch_date = :schDate AND s.approve='Y') AND s.time > CURRENT_TIMESTAMP ORDER BY t.id,s.time""", nativeQuery = true)
+        WHERE (c.id = :id AND s.sch_date = :schDate AND s.approve='Y') AND s.time > :localDateTime
+        ORDER BY t.id,s.time""", nativeQuery = true)
     List<IScheduleInfoDto> findScheduleDetailsByDateAndCinemaId(@Param("id") Long id,
-                                                                @Param("schDate") LocalDate schDate);
+                                                                @Param("schDate") LocalDate schDate,
+                                                                @Param("localDateTime")LocalDateTime localDateTime);
 
     //  WHERE (c.id = :id AND s.sch_date = :schDate) AND s.time > CURRENT_TIMESTAMP """, nativeQuery = true)
 
@@ -82,8 +92,9 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
         JOIN schedule s ON s.theater_id = t.id
         JOIN movie_list ml ON ml.cinema_id = c.id
         JOIN movie m ON m.id = ml.movie_id AND m.id = s.movie_id
-        WHERE (m.id= :movieId AND c.id = :cinemaId AND s.sch_date = :schDate AND s.approve='Y') AND s.time > CURRENT_TIMESTAMP ORDER BY t.id,s.time""", nativeQuery = true)
-    List<IScheduleInfoDto> findScheduleDetailsByDateAndCinemaId_2(Long movieId, Long cinemaId, LocalDate schDate);
+        WHERE (m.id= :movieId AND c.id = :cinemaId AND s.sch_date = :schDate AND s.approve='Y') AND s.time > :localDateTime 
+        ORDER BY t.id,s.time""", nativeQuery = true)
+    List<IScheduleInfoDto> findScheduleDetailsByDateAndCinemaId_2(Long movieId, Long cinemaId, LocalDate schDate,LocalDateTime localDateTime);
 
     Long countByMovieId(Long movieId);
 
@@ -92,8 +103,8 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
 
     //해당 영화, 지점으로 현재기준으로 미래인 상영스케쥴 조회(단, 승인된 스케쥴이여야 한다)
-    @Query("SELECT s FROM Schedule s JOIN s.theater t WHERE t.cinema.id = :cinemaId AND s.movie.id = :movieId AND s.approve='Y' AND s.time > CURRENT_TIMESTAMP ")
-    List<Schedule> searchMovieSchedule(Long cinemaId, Long movieId);
+    @Query("SELECT s FROM Schedule s JOIN s.theater t WHERE t.cinema.id = :cinemaId AND s.movie.id = :movieId AND s.approve='Y' AND s.time > :localDateTime ")
+    List<Schedule> searchMovieSchedule(Long cinemaId, Long movieId,LocalDateTime localDateTime);
 
 
     //0428 극장에서 상영일정 클릭해서 바로 예매페이지 넘어가는 경우! 상영일정id 하나만으로 조회 시도

--- a/src/main/java/com/sh/app/schedule/service/ScheduleService.java
+++ b/src/main/java/com/sh/app/schedule/service/ScheduleService.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -61,7 +62,9 @@ public class ScheduleService {
 
     //0218 - 특정 영화, 극장 지점 ,시간 조건에 맞는 스케쥴들 출력[test]
     public List<IScheduleInfoDto> findScheduleDetailsByDateAndCinemaId_2(Long movieId, Long cinemaId, LocalDate schDate) {
-        return scheduleRepository.findScheduleDetailsByDateAndCinemaId_2(movieId, cinemaId,schDate);
+        ZoneId zoneId = ZoneId.of("Asia/Seoul");
+        LocalDateTime localDateTime = LocalDateTime.now(zoneId);
+        return scheduleRepository.findScheduleDetailsByDateAndCinemaId_2(movieId, cinemaId,schDate,localDateTime);
     }
 
     private ScheduleDto convertToDto(Schedule schedule) {
@@ -106,7 +109,9 @@ public class ScheduleService {
 
     //origin
     public List<IScheduleInfoDto> findScheduleDetailsByDateAndCinemaId(Long id, LocalDate schDate) {
-        return scheduleRepository.findScheduleDetailsByDateAndCinemaId(id, schDate);
+        ZoneId zoneId = ZoneId.of("Asia/Seoul");
+        LocalDateTime localDateTime = LocalDateTime.now(zoneId);
+        return scheduleRepository.findScheduleDetailsByDateAndCinemaId(id, schDate,localDateTime);
     }
 
     public List<ScheduleListDto> findScheduleWithTheaterId(Long theaterId) {
@@ -263,7 +268,9 @@ public class ScheduleService {
     public List<SearchMovieScheduleDto> searchMovieSchedule(Long cinemaId,Long movieId){
     // 현재 시네마 아이디, 영화 아이디를 사용해 해당 지점에서만 상영되는 해당 영화의 스케쥴만 가져온다.
         System.out.println("searchMovieSchedule - service !");
-        return scheduleRepository.searchMovieSchedule(cinemaId,movieId)
+        ZoneId zoneId = ZoneId.of("Asia/Seoul");
+        LocalDateTime localDateTime = LocalDateTime.now(zoneId);
+        return scheduleRepository.searchMovieSchedule(cinemaId,movieId,localDateTime)
                 .stream().map((schedule) -> entityToDtos(schedule))
                 .collect(Collectors.toList());
     }

--- a/src/main/resources/templates/admin/adminRegion.html
+++ b/src/main/resources/templates/admin/adminRegion.html
@@ -141,14 +141,14 @@
                                 </td>
                                 <td class="td-movieTitle" th:text="${movie.movieTitle}"></td>
                                 <td class="td-movieID" th:text="${movie.movieId}"></td>
-                                <td class="td-searchMovieSchedule">
-                                    <button
-                                            id="searchMovieSchedule"
-                                            th:data-id="${movie.id}"
-                                            th:data-cinemaId="${movie.cinemaId}"
-                                            th:data-movieId="${movie.movieId}"
-                                            onclick="searchMovieSchedule(this.getAttribute('data-id'),this.getAttribute('data-cinemaId'),this.getAttribute('data-movieId'))">상영일정조회</button>
-                                </td>
+<!--                                <td class="td-searchMovieSchedule">-->
+<!--                                    <button-->
+<!--                                            id="searchMovieSchedule"-->
+<!--                                            th:data-id="${movie.id}"-->
+<!--                                            th:data-cinemaId="${movie.cinemaId}"-->
+<!--                                            th:data-movieId="${movie.movieId}"-->
+<!--                                            onclick="searchMovieSchedule(this.getAttribute('data-id'),this.getAttribute('data-cinemaId'),this.getAttribute('data-movieId'))">상영일정조회</button>-->
+<!--                                </td>-->
 
                                 <td class="td-deleteMovie">
                                     <button

--- a/src/main/resources/templates/member/memberWatchedMovie.html
+++ b/src/main/resources/templates/member/memberWatchedMovie.html
@@ -63,6 +63,7 @@
                                     <img loading="lazy" class="w-40 h-60 movie_img-item movie_img-first" src="https://t4.ftcdn.net/jpg/03/08/67/51/360_F_308675145_Ye70fJFVPntNVnmxjtVgMy5P8MDEmusB.jpg">
                                 </th:block>
                                 <th:block th:if="|${schedule.movie.posterUrl != null and #strings.startsWith(schedule.movie.posterUrl, 'http://file.koreafilm.or.kr')}|">
+                                    <a th:href="@{/movie/movieDetail.do(id=${schedule.movie.id})}">
                                     <img loading="lazy" class="w-40 h-60 movie_img-item movie_img-first" th:src="${schedule.movie.posterUrl}" th:alt="${movie.title}">
                                 </th:block>
                                 <th:block th:if="|${schedule.movie.posterUrl != null and !#strings.startsWith(schedule.movie.posterUrl, 'http://file.koreafilm.or.kr')}|">


### PR DESCRIPTION
0610
원인:
로컬에선 정상적으로 현재시간 currentTimeStamp가 작동하지만,
서버에서는 utc 이슈로 9시간 늦게 시간이 적용됩니다.(정호씨 피드백으로 알게됨)
해결:
쿼리문 where절에서 상영시간>current_timestamp 대신 아래로 대체
ZoneId zoneId = ZoneId.of("Asia/Seoul");
LocalDateTime localDateTime = LocalDateTime.now(zoneId);